### PR TITLE
Fixes known runtime and syntax errors

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,18 @@
+table {
+  border-collapse: collapse;
+  border: 1px solid #ddd;
+}
+
+th {
+  background-color: #f2f2f2;
+  font-weight: bold;
+}
+
+tr:nth-child(odd) {
+  background-color: #f2f2f2;
+}
+
+td, th {
+  min-width: 100px;
+  text-align: center;
+}

--- a/index.html
+++ b/index.html
@@ -10,5 +10,16 @@
 </head>
 <body>
   <h1>LacOp Simulation</h1>
+  <table id="temp-table">
+    <tr>
+      <th>Time</th>
+      <th>allo</th>
+      <th>bgal</th>
+      <th>glucose + galactose</th>
+      <th>lacIn</th>
+      <th>lacOut</th>
+      <th>perm</th>
+    </tr>
+  </table>
 </body>
 </html>

--- a/js/GenomeInfo.js
+++ b/js/GenomeInfo.js
@@ -1,17 +1,7 @@
-// 7/9/2024
-
-/* File: GenomeInfo
-Author: Richard Charczenko
-version: 2 */
-
-// Object.keys(obj) - returns list of keys   .includes
-
 class Genome {
     constructor(mutations){
         this.mut = mutations;
         this.counter = 0;
-        // iterator counter
-        this.visited = [];
     }
     has(item){
         if(item in this.mut) {
@@ -36,7 +26,7 @@ class Genome {
         Promoter research article
         https://www.ncbi.nlm.nih.gov/pmc/articles/PMC178712/pdf/1790423.pdf
         */
-        return self.mut["ProMutation"] === null;
+        return this.mut["ProMutation"] === null;
     }
     operator(allo, lacOut, rep, glucose){
         /* Lactose operon operator, if there is no mutation within the operator
@@ -48,34 +38,15 @@ class Genome {
             Bool true or false, represents operator on or off.
         pre:
             only is affected by repressor when no mutations */
-        if(self.mut["OpMutation"] === null) {
-            for(let r in rep) {
-                if(!(r.bound(allo, lacOut, glucose))) { ///////////////
+        if(this.mut["OpMutation"] === null) {
+            for(let r of rep) {
+                if(!(r.bound(allo, lacOut, glucose))) {
                     return false;
                 }
             }
         }
         return true;
     }
-//////////////////////////////////////////
-
-    ///////////////iter
-
-
-    next(){ ////////////////////////
-        if(this.counter < length(this.mut)) {
-            ////////////////////
-        } else {
-            this.counter = 0;
-            this.visited = [];
-            /////////////////////
-        }
-    }
-
-
-
-    /// __str__ ///////////////////
-
-/////////////////////////////////////////////
 }
+
 export default Genome;

--- a/js/LacOp.js
+++ b/js/LacOp.js
@@ -1,6 +1,5 @@
 /* Driver file for the LacOp project */
-import { Cell } from './cellClass';
-
+import Cell from './cellClass.js';
 
 function RunLO(mutL, plasmid, allo, lacIn, lacOut, Glu) {
     const mutations = convert_mutList_to_dict(mutL);
@@ -8,10 +7,10 @@ function RunLO(mutL, plasmid, allo, lacIn, lacOut, Glu) {
     if ("Active" in mutL) { 
         cap = "Active";
     }
-    var C = Cell(mutations, allo, lacIn, lacOut, Glu, cap);
-    if(plasmid != []){
+    var C = new Cell(mutations, allo, lacIn, lacOut, Glu, cap);
+    if(plasmid.length > 0){
         var shift = [];
-        for(let item in plasmid){
+        for(let item of plasmid){
             /////////////
             const slicedItem = item.slice(2);
             shift.push(slicedItem);
@@ -27,7 +26,7 @@ function convert_mutList_to_dict(list) {
     var mutL = {'ProMutation': null, 'BgalMutation': null,
         'RepMutation': null, 'OpMutation': null,
         'PermMutation': null};
-    for (let item in list){ 
+    for (let item of list){ 
         let sliceItem = item.slice(0,4);
         if(sliceItem != "none"){ 
             if (item == "lacP-"){
@@ -49,3 +48,6 @@ function convert_mutList_to_dict(list) {
     }
     return mutL;
 }
+
+// consider instead making a "Simulation" object that takes place of the "generateData" function, allowing front end to step through the simulation
+export { RunLO, convert_mutList_to_dict };

--- a/js/bGal.js
+++ b/js/bGal.js
@@ -1,5 +1,3 @@
-// 7/11/2024
-
 class Bgal{
     /* mimics the functionality of B-Gal, assuming Mg is a cofactor
     and reaction takes place at 30 degrees C. */
@@ -12,20 +10,26 @@ class Bgal{
         this.age += 1;
         const p = (lacIn/(allo+lacIn));
         const choice = Math.random();
-        if (this.mut == "lacZ-"){
-            return 0, "lac";
-        }
-        if (allo < 1 && lacIn < 1){
-            return 0, "lac";
+        let changes = {
+            "lac": 0,
+            "allo": 0,
+            "gluGal": 0
+        };
+        if (this.mut == "lacZ-" || allo < 1 && lacIn < 1){
+            return changes;
         }
         if (choice < p && lacIn > 1) {
-            return self.Lrate(lacIn), "lac";
+            const change = this.Lrate(lacIn);
+            changes["lac"] = change * -1;
+            changes["allo"] = change;
+        } else if(allo > 1){
+            const change = this.Arate(allo);
+            changes["allo"] = change * -1;
+            changes["gluGal"] = change;
         }
-        if(allo > 1){
-            return self.Arate(allo), "allo";
-        }
-        return 0, "allo";
+        return changes;
     }
+
     Arate(allo) {
         /* Uses the Michaelis menten equation and the current concentration of allolactose
         to determine the rate or the amount of allolactose reduced */

--- a/js/cc_Complex.js
+++ b/js/cc_Complex.js
@@ -1,5 +1,3 @@
-
-
 class CAPcAMP {
     constructor(status) {
         if(status == "Inactive") {
@@ -15,4 +13,5 @@ class CAPcAMP {
         return this.status; // if(glucose <= 100)
     }
 }
+
 export default CAPcAMP;

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,27 @@
+import { RunLO } from "./LacOp.js";
+
+// temp, delete all below later
+const simCell = RunLO(['noneP', 'ALLO', 'LO', 'noneZ', 'noneY', 'LI', 'GLU', 'Inactive', 'noneO', 'noneI'], [], 0, 0, 200, 0);
+const timeTable = document.getElementById("temp-table");
+// insert row for each time point
+for (let i = 0; i < simCell.time; i++) {
+  const row = timeTable.insertRow();
+  const timeCell = row.insertCell();
+  const alloCell = row.insertCell();
+  const bgalCell = row.insertCell();
+  const glucoseCell = row.insertCell();
+  const lacInCell = row.insertCell();
+  const lacOutCell = row.insertCell();
+  const permCell = row.insertCell();
+
+  timeCell.innerHTML = i;
+  alloCell.innerHTML = simCell.archiveConditions.allo[i].toFixed(3);
+  bgalCell.innerHTML = simCell.archiveConditions.bgal[i];
+  glucoseCell.innerHTML = simCell.archiveConditions["glucose + galactose"][i].toFixed(3);
+  lacInCell.innerHTML = simCell.archiveConditions.lacIn[i].toFixed(3);
+  lacOutCell.innerHTML = simCell.archiveConditions.lacOut[i].toFixed(3);
+  permCell.innerHTML = simCell.archiveConditions.perm[i];
+}
+
+// for debugging, get cell object from console
+window.cell = simCell;

--- a/js/permease.js
+++ b/js/permease.js
@@ -1,11 +1,4 @@
-// 7/9/2024
-
-/* Author: Richard Charczenko
-Last Edited: 11/20/2018
-
-Any research articles for permease should be listed below: */
-
-class permease {
+class Permase {
     /* mimics permease membrane protein, is constructed with either no mutation
     or a non-functional mutation (lacY-).
 
@@ -15,7 +8,7 @@ class permease {
     Implemenation invariance: the lacY- causes the rate function to always increment
     the passed in doubles by 0. */
 
-    static permeaseMut = {null:0.2, "lacY-":0.0 };
+    static permeaseMut = {"none":0.2, "lacY-":0.0 };
 
     constructor(mut){
         this.mut = mut; //allows for some permease to have mutations
@@ -26,13 +19,14 @@ class permease {
         this.age += 1;
         if(lacO > 1.0){
             //permease is based on a equilibrium, need to do research here
-            return (lacO - this.permeaseMut[this.mut]), (lacI + this.permeaseMut[this.mut])
-
+            return {
+                lacOut: lacO - Permase.permeaseMut[this.mut ?? "none"],
+                lacIn: lacI + Permase.permeaseMut[this.mut ?? "none"]
+            }
         }
-        return lacO, lacI;
+        return {lacOut: lacO, lacIn: lacI};
     }
 
 }
 
-
-export default permease;
+export default Permase;

--- a/js/repressor.js
+++ b/js/repressor.js
@@ -1,16 +1,12 @@
-// is static used correctly here
-
-
 class Repressor {
     /* Mimics repressor protein function, but in lacop program we assume
     that the repressor protein concentration is constant. If repressor is
     unbound that is represented as the boolean True */
 
-    //is static correct to use here for class variables?
-    static repressorMut = {null: "active", "lacI-": "inactive", "lacIs": "stuck"};
+    static repressorMut = {"none": "active", "lacI-": "inactive", "lacIs": "stuck"};
 
-    constructor(mut) { 
-        this.status = this.repressorMut[mut];
+    constructor(mut) {
+        this.status = Repressor.repressorMut[mut ?? "none"] ?? "active";
     }
 
     bound(allo, Le, glu) {
@@ -18,7 +14,7 @@ class Repressor {
             return false;
         }
         if (this.status == "active") {
-            return self.conditionCheck(allo, Le, glu);
+            return this.conditionCheck(allo, Le, glu);
         }
         return true; //if(this.status == "inactive")
     }


### PR DESCRIPTION
- Fixes uses of self instead of this
- Fixes modules imports to end in .js (needed in browser) and default imports
- Fixes missing new keyword for some object creations
- Fixes the use of `in` instead of `of` in for loops
- Fixes pythonic multiple return values with a returned object
- Fixes pythonic foreach syntax on an object/dict with the js equivalent
- Fixes a improperly nested if statement in Cell.backgroundTranscription()
- Fixes use of null as a key
- Fixes referencing static members with `this` instead of the class name
- Adds a temporary time table for future debugging